### PR TITLE
Lpfrevup2020 73

### DIFF
--- a/src/components/SpeakerBox.vue
+++ b/src/components/SpeakerBox.vue
@@ -1,12 +1,15 @@
 <template lang="pug">
-  v-layout.speaker-layout
-    v-card.mr-2.mb-3(
+  .speaker-layout
+    .mr-2.mb-3.box(
       @click="moveToSpeakerPage()"
     )
-      v-img(
+      v-img.rounded-circle.mx-auto(
+        width="200"
         :src="speakerImageUrl"
+        :aspect-ratio="1/1"
+        contain
       )
-      v-card-text
+      v-card-text.text-center
         div.pb-4.text-subtitle-2.text-md-h6 {{ speaker.familyNameJp }} {{ speaker.firstNameJp }}
         div.text-body-2.text-md-subtitle-2 {{ speaker.affiliation }} {{ speaker.title }}
 </template>
@@ -24,7 +27,7 @@ export default class SpeakerBoxComponent extends Vue {
     // See microCMS image API
     // https://microcms.io/docs/image-api/introduction
     // https://docs.imgix.com/apis/url/mask/corner-radius
-    return `${this.speaker.image.url}?fit=crop&w=270&h=150`
+    return `${this.speaker.image.url}?fit=crop&w=270&h=270`
   }
 
   moveToSpeakerPage() {
@@ -35,4 +38,6 @@ export default class SpeakerBoxComponent extends Vue {
 <style lang="stylus">
 .speaker-layout
   height 100%
+.box
+  cursor pointer
 </style>

--- a/src/pages/speakers/_id.vue
+++ b/src/pages/speakers/_id.vue
@@ -16,7 +16,7 @@
           )
             v-col.mb-4(cols="12" md="4")
               v-layout(justify-center)
-                v-img.rounded-lg(:src="speaker.image.url" width="272" max-width="100%" :alt="speakerFullName" :aspect-ratio="1/1")
+                v-img.rounded-circle(:src="speaker.image.url" width="272" max-width="100%" :alt="speakerFullName" :aspect-ratio="1/1")
             v-col(cols="12" md="8")
               div.headline.font-weight-black.text-center.text-md-left {{ speakerFullName }}
               div.text-subtitle-1.text-center.text-md-left {{ speaker.affiliation }} {{ speaker.title }}


### PR DESCRIPTION
+ 登壇者画像を円形に変更
+ テキストを中央寄せに変更

## PC
<img width="1378" alt="スクリーンショット 2020-09-08 16 53 13" src="https://user-images.githubusercontent.com/13013149/92456598-184e6700-f1fe-11ea-99c0-51884cf80868.png">

## SP
<img width="335" alt="スクリーンショット 2020-09-08 16 54 07" src="https://user-images.githubusercontent.com/13013149/92456604-1ab0c100-f1fe-11ea-8bcf-3545ec712f94.png">

